### PR TITLE
fix: Show badge icon only for users with contributions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -337,7 +337,7 @@ function App() {
                         <span>{userContribs[index].count} contributions</span>
                       </div>
                       <div>
-                        {index < 3 && (
+                        {index < 3 && userContribs[index].count > 0 && (
                           <FontAwesomeIcon
                             icon={faCertificate}
                             className="badge-icon"


### PR DESCRIPTION
Display the badge icon only for users who have made contributions, enhancing the clarity of user contributions.